### PR TITLE
画面サイズによって生成ボタンが表示できない問題を解決

### DIFF
--- a/index.css
+++ b/index.css
@@ -94,9 +94,30 @@ main {
     display: inline-block;
     background: orange;
 }
-#save {
+.btn-text {
     line-height: 50px;
     font-size: 25px;
     text-decoration: none;
     color: #fff;
+}
+.make-btn {
+    margin: 10px;
+}
+#mobile {
+    display: none;
+}
+@media only screen and (max-width:500px){
+    #PC {
+        display: none;
+    }
+    #mobile {
+        display: block;
+    }
+    .make-btn {
+        margin: 10px 10px 10px 60px;
+        float: left;
+    }
+    .model {
+        float: left;
+    }
 }

--- a/index.html
+++ b/index.html
@@ -45,18 +45,23 @@
 		</div>
 	</header>
 	<main>
-		<dl>お手本</dl><img src="./img/icon.png" width="20%" height="20%">
+		<img class="model" src="./img/icon.png" width="20%" height="20%">
+		<div class="button make-btn" id="mobile" style="background: green;">
+			<a id="make" class="btn-text" onclick="make_img()"><i class="far fa-image"></i> Make Image</a>
+		</div>
 		<div id="canvas-wrapper"
-			style="max-width: 100%; width:460px; height: auto; padding: 10px; margin-bottom: 10px; border: 1px solid #333333; background-color:#e8e8e8;">
+			style="clear: both; max-width: 100%; width:460px; height: auto; padding: 10px; margin-bottom: 10px; border: 1px solid #333333; background-color:#e8e8e8;">
 			<canvas id='Canvas1' width="" height=""></canvas>
 		</div>
-		<input id="make" type="button" value="画像を生成" onclick="make_img()">
+		<div class="button make-btn" id="PC" style="background: green;">
+			<a id="make" class="btn-text" onclick="make_img()"><i class="far fa-image"></i> Make Image</a>
+		</div>
 		<div id="glayLayer"></div>
 		<div id="overLayer">
 			<img id="img-hakuyo"　src="" alt="">
 			<div class="menu">
-				<div class="button">
-					<a id="save" href="" download="hakuyo-warai.png"><i class="fas fa-file-download"></i> Download</a>
+				<div class="button" style="background: orange;">
+					<a id="save" class="btn-text" href="" download="hakuyo-warai.png"><i class="fas fa-file-download"></i> Download</a>
 				</div>
 				<div class="share">
 					<a href="https://twitter.com/share?url=https://hakuyo-warai.now.sh/&amp;text=ハクヨウを笑わせよう%0A"
@@ -71,6 +76,9 @@
 			</div>
 		</div>
 	</main>
+	<footer>
+		<small>Copyright &copy; 2020 Hakuyo-Warai</small>
+	</footer>
 </body>
 
 </html>


### PR DESCRIPTION
画面幅が500px以下だと、生成ボタンが、見本の隣に表示されます。